### PR TITLE
Implement Scheduler for Folia support

### DIFF
--- a/.idea/runConfigurations/RunFolia_1_21.xml
+++ b/.idea/runConfigurations/RunFolia_1_21.xml
@@ -1,0 +1,9 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="RunFolia 1.21" type="JarApplication" folderName="Run server">
+    <option name="JAR_PATH" value="$PROJECT_DIR$/Testing/servers/folia-1.21.jar" />
+    <option name="VM_PARAMETERS" value="-Xms4G -Xmx4G -jar" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$\Testing" />
+    <option name="ALTERNATIVE_JRE_PATH" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/src/main/java/com/faridfaharaj/profitable/Scheduler.java
+++ b/src/main/java/com/faridfaharaj/profitable/Scheduler.java
@@ -1,0 +1,39 @@
+package com.faridfaharaj.profitable;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Server;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitRunnable;
+
+public final class Scheduler {
+
+    private static boolean isFolia;
+    private static final Plugin plugin;
+
+    static {
+        try {
+            Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+            isFolia = true;
+        } catch (final ClassNotFoundException ignored) {
+            isFolia = false;
+        }
+        plugin = Profitable.getInstance();
+    }
+
+    public static void runAtLocation(Location location, Runnable task) {
+        if (isFolia) {
+            // Folia: Use RegionScheduler to run at this location's region
+            Server server = Bukkit.getServer();
+            server.getRegionScheduler().execute(plugin, location, task);
+        } else {
+            // Paper/Spigot fallback
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    task.run();
+                }
+            }.runTask(plugin);
+        }
+    }
+}

--- a/src/main/java/com/faridfaharaj/profitable/data/holderClasses/Asset.java
+++ b/src/main/java/com/faridfaharaj/profitable/data/holderClasses/Asset.java
@@ -1,5 +1,6 @@
 package com.faridfaharaj.profitable.data.holderClasses;
 
+import com.faridfaharaj.profitable.Scheduler;
 import com.faridfaharaj.profitable.data.tables.Accounts;
 import com.faridfaharaj.profitable.data.tables.AccountHoldings;
 import com.faridfaharaj.profitable.util.RandomUtil;
@@ -240,36 +241,38 @@ public class Asset {
         int maxStackSize = material.getMaxStackSize();
 
         Location location = Accounts.getItemDelivery(account);
-        World world = location.getWorld();
-        Block block = location.getBlock();
-        if (block.getState() instanceof Chest) {
-            Chest chest = (Chest) block.getState();
 
-            int missing = amount;
-            while (missing > 0) {
-                int giveAmount = Math.min(missing, maxStackSize);
-                ItemStack itemStack = new ItemStack(material, giveAmount);
+        Scheduler.runAtLocation(location, () -> {
+            World world = location.getWorld();
+            Block block = location.getBlock();
+            if (block.getState() instanceof Chest) {
+                Chest chest = (Chest) block.getState();
+
+                int missing = amount;
+                while (missing > 0) {
+                    int giveAmount = Math.min(missing, maxStackSize);
+                    ItemStack itemStack = new ItemStack(material, giveAmount);
 
 
-                Inventory inventory = chest.getInventory();
-                for (ItemStack drop : inventory.addItem(itemStack).values()) {
-                    world.dropItemNaturally(location, drop);
+                    Inventory inventory = chest.getInventory();
+                    for (ItemStack drop : inventory.addItem(itemStack).values()) {
+                        world.dropItemNaturally(location, drop);
+                    }
+
+                    missing -= giveAmount;
                 }
 
-                missing -= giveAmount;
+            }else{
+
+                world.dropItemNaturally(location, new ItemStack(material, amount));
+
             }
 
-        }else{
-
-            world.dropItemNaturally(location, new ItemStack(material, amount));
-
-        }
-
-        world.spawnParticle(Particle.FIREWORK, location.add(0.5,0.5,0.5), 5);
-        world.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
-        world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
-        world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
-
+            world.spawnParticle(Particle.FIREWORK, location.add(0.5,0.5,0.5), 5);
+            world.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
+            world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
+            world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
+        });
     }
 
     public static void sendCommodityEntity(String player, String asset, String id, int amount){
@@ -277,19 +280,20 @@ public class Asset {
         EntityType entityType = EntityType.fromName(asset);
 
         Location location = Accounts.getEntityDelivery(player);
-        World world = location.getWorld();
+        Scheduler.runAtLocation(location, () -> {
+            World world = location.getWorld();
 
-        for(int i = 0; i<amount; i++){
-            Entity entity = world.spawnEntity(location, entityType);
-            entity.setCustomName(id);
-            entity.setCustomNameVisible(true);
-        }
+            for(int i = 0; i<amount; i++){
+                Entity entity = world.spawnEntity(location, entityType);
+                entity.setCustomName(id);
+                entity.setCustomNameVisible(true);
+            }
 
-        world.spawnParticle(Particle.FIREWORK, location, 10);
-        world.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
-        world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
-        world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
-
+            world.spawnParticle(Particle.FIREWORK, location, 10);
+            world.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
+            world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
+            world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
+        });
     }
 
     public static boolean retrieveAsset(Player player, String notice, String asset, int assetType, double ammount){

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,6 +8,7 @@ description: "Real supply and demand in minecraft!"
 website: "https://github.com/faridfaharaj/Profitable"
 softdepend:
   - Vault
+folia-supported: true
 
 commands:
   profitable:


### PR DESCRIPTION
# Implement Scheduler for Folia support

## Summary

This PR adds support for Folia by implementing a unified `Scheduler` utility class. It detects whether the server is running Folia and uses the appropriate region-aware scheduler to ensure compatibility with Folia's multithreaded environment.

## Changes

- Added `Scheduler` utility class to detect Folia and provide access to `RegionScheduler`.
- Refactored `sendCommodityItem()` and `sendCommodityEntity()` to use `RegionScheduler` to safely access and modify blocks in other regions/dimensions (e.g., overworld chests while the player is in the nether).
- Added fallback behavior for non-Folia (Paper) servers.

## Why

Folia introduces region-based multithreading, which disallows cross-region/world access from a single thread. This caused exceptions when trying to access blocks in different dimensions (like overworld chests from the nether). This PR resolves that.

## Compatibility

- ✅ Fully compatible with Folia
- ✅ Fully compatible with Paper (via fallback behavior)