### PR TITLE
Add Minecraft 1.20.4 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <name>Profitable</name>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -97,19 +97,23 @@
             <id>rosewood-repo</id>
             <url>https://repo.rosewooddev.io/repository/public/</url>
         </repository>
+        <repository>
+            <id>tcoded-releases</id>
+            <url>https://repo.tcoded.com/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.20.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.technicallycoded</groupId>
+            <groupId>com.tcoded</groupId>
             <artifactId>FoliaLib</artifactId>
-            <version>main-SNAPSHOT</version>
+            <version>0.5.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/faridfaharaj/profitable/Events.java
+++ b/src/main/java/com/faridfaharaj/profitable/Events.java
@@ -144,8 +144,8 @@ public class Events implements Listener {
         if(Configuration.MULTIWORLD){
             Assets.generateAssets(event.getWorld());
             Accounts.registerDefaultAccount(event.getWorld(), "server");
-            Accounts.changeEntityDelivery(event.getWorld(), "server", new Location(Profitable.getInstance().getServer().getWorlds().getFirst(), 0, 0 ,0));
-            Accounts.changeItemDelivery(event.getWorld(), "server", new Location(Profitable.getInstance().getServer().getWorlds().getFirst(), 0, 0 ,0));
+            Accounts.changeEntityDelivery(event.getWorld(), "server", new Location(Profitable.getInstance().getServer().getWorlds().get(0), 0, 0 ,0));
+            Accounts.changeItemDelivery(event.getWorld(), "server", new Location(Profitable.getInstance().getServer().getWorlds().get(0), 0, 0 ,0));
         }
     }
 

--- a/src/main/java/com/faridfaharaj/profitable/Profitable.java
+++ b/src/main/java/com/faridfaharaj/profitable/Profitable.java
@@ -108,16 +108,16 @@ public final class Profitable extends JavaPlugin {
             for(World world : this.getServer().getWorlds()){
                 Assets.generateAssets(world);
                 Accounts.registerDefaultAccount(world, "server");
-                Accounts.changeEntityDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().getFirst(), 0, 0 ,0));
-                Accounts.changeItemDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().getFirst(), 0, 0 ,0));
+                Accounts.changeEntityDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().get(0), 0, 0 ,0));
+                Accounts.changeItemDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().get(0), 0, 0 ,0));
             }
             getLogger().info("Using per-world data");
         }else{
-            World world = getServer().getWorlds().getFirst();
+            World world = getServer().getWorlds().get(0);
             Assets.generateAssets(world);
             Accounts.registerDefaultAccount(world, "server");
-            Accounts.changeEntityDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().getFirst(), 0, 0 ,0));
-            Accounts.changeItemDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().getFirst(), 0, 0 ,0));
+            Accounts.changeEntityDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().get(0), 0, 0 ,0));
+            Accounts.changeItemDelivery(world, "server", new Location(Profitable.getInstance().getServer().getWorlds().get(0), 0, 0 ,0));
             getLogger().info("Using single server-wide data");
         }
 

--- a/src/main/java/com/faridfaharaj/profitable/data/holderClasses/Asset.java
+++ b/src/main/java/com/faridfaharaj/profitable/data/holderClasses/Asset.java
@@ -8,6 +8,7 @@ import com.faridfaharaj.profitable.hooks.PlayerPointsHook;
 import com.faridfaharaj.profitable.hooks.VaultHook;
 import com.faridfaharaj.profitable.util.RandomUtil;
 import com.faridfaharaj.profitable.util.MessagingUtil;
+import com.faridfaharaj.profitable.util.ParticleCompat;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextColor;
 import org.bukkit.*;
@@ -322,7 +323,7 @@ public class Asset {
                 entity.setCustomNameVisible(true);
             }
 
-            world.spawnParticle(Particle.FIREWORK, location, 10);
+            world.spawnParticle(ParticleCompat.firework(), location, 10);
             world.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
             world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
             world.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
@@ -363,7 +364,7 @@ public class Asset {
 
                     }
 
-                    deliveryWorld.spawnParticle(Particle.FIREWORK, location.add(0.5,0.5,0.5), 5);
+                    deliveryWorld.spawnParticle(ParticleCompat.firework(), location.add(0.5,0.5,0.5), 5);
                     deliveryWorld.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
                     deliveryWorld.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
                     deliveryWorld.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
@@ -387,7 +388,7 @@ public class Asset {
                 entity.setCustomNameVisible(true);
             }
 
-            deliveryWorld.spawnParticle(Particle.FIREWORK, location, 10);
+            deliveryWorld.spawnParticle(ParticleCompat.firework(), location, 10);
             deliveryWorld.playSound(location, Sound.ENTITY_EXPERIENCE_ORB_PICKUP, 1,1);
             deliveryWorld.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_BLAST, 1,1);
             deliveryWorld.playSound(location, Sound.ENTITY_FIREWORK_ROCKET_TWINKLE, 1,1);
@@ -596,7 +597,7 @@ public class Asset {
                 World world = player.getWorld();
                 for(Entity retrieved : entities){
                     world.playSound(retrieved.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1, 1);
-                    world.spawnParticle(Particle.HAPPY_VILLAGER, retrieved.getLocation(), 5, 1,1,1,1);
+                    world.spawnParticle(ParticleCompat.happyVillager(), retrieved.getLocation(), 5, 1,1,1,1);
                     retrieved.remove();
                 }
                 return true;

--- a/src/main/java/com/faridfaharaj/profitable/data/tables/AccountHoldings.java
+++ b/src/main/java/com/faridfaharaj/profitable/data/tables/AccountHoldings.java
@@ -109,15 +109,15 @@ public class AccountHoldings {
                     if(!Objects.equals(assetCode, Configuration.MAINCURRENCYASSET.getCode())){
                         value = rs.getDouble("value");
                     }else {
-                        balances.addFirst(new AssetCache(asset, new Candle(0, 1, 0,0, quantity)));
+                        balances.add(0, new AssetCache(asset, new Candle(0, 1, 0,0, quantity)));
                         continue;
                     }
 
                     balances.add(new AssetCache(asset, new Candle(0, value, 0,0, quantity)));
                 }
 
-                if(balances.isEmpty() || !Objects.equals(balances.getFirst().getAsset().getCode(), Configuration.MAINCURRENCYASSET.getCode())){
-                    balances.addFirst(new AssetCache(Configuration.MAINCURRENCYASSET, new Candle(0, 1, 0,0, 0)));
+                if(balances.isEmpty() || !Objects.equals(balances.get(0).getAsset().getCode(), Configuration.MAINCURRENCYASSET.getCode())){
+                    balances.add(0, new AssetCache(Configuration.MAINCURRENCYASSET, new Candle(0, 1, 0,0, 0)));
                 }
 
             }

--- a/src/main/java/com/faridfaharaj/profitable/exchange/Books/Exchange.java
+++ b/src/main/java/com/faridfaharaj/profitable/exchange/Books/Exchange.java
@@ -184,12 +184,12 @@ public class Exchange {
                 if(finalPartialOrder != null){
 
                     Orders.updateOrderUnits(player.getWorld(), finalPartialOrder.getUuid(), finalPartialOrder.getUnits());
-                    ordersToDelete.removeLast();
+                    ordersToDelete.remove(ordersToDelete.size() - 1);
 
                 }
                 wrapTransactions(player, order, orders, takerFee, tradedAsset, collateralAsset, finalMoneyTransacted, unitsTransacted);
-                Candles.updateDay(player.getWorld(), tradedAsset.getCode(), orders.getLast().getPrice(), unitsTransacted);
-                Orders.updateStopLimit(player.getWorld(), lastday.getClose(), orders.getLast().getPrice());
+                Candles.updateDay(player.getWorld(), tradedAsset.getCode(), orders.get(orders.size() - 1).getPrice(), unitsTransacted);
+                Orders.updateStopLimit(player.getWorld(), lastday.getClose(), orders.get(orders.size() - 1).getPrice());
                 Orders.deleteOrders(player.getWorld(), ordersToDelete);
             });
         });

--- a/src/main/java/com/faridfaharaj/profitable/tasks/MapGraphRenderer.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/MapGraphRenderer.java
@@ -68,8 +68,8 @@ public class MapGraphRenderer extends MapRenderer {
             return;
         }
 
-        double lowest = candles.getLast().getLow();
-        double highest = candles.getLast().getHigh();
+        double lowest = candles.get(candles.size() - 1).getLow();
+        double highest = candles.get(candles.size() - 1).getHigh();
 
         if(highest == lowest){
             canvas.drawText(25, bottom - top/2 - 5, MinecraftFont.Font, "No price change");
@@ -117,7 +117,7 @@ public class MapGraphRenderer extends MapRenderer {
 
 
             if(volume > 0){
-                volume = bottom - (int) Math.ceil(volume / candles.getLast().getVolume() * ((double) top /3));
+                volume = bottom - (int) Math.ceil(volume / candles.get(candles.size() - 1).getVolume() * ((double) top /3));
                 shadedRectangle(canvas, offset+spacing, bottom,offset+wideness-1, (int) volume, volumeColor);
             }
 

--- a/src/main/java/com/faridfaharaj/profitable/tasks/TemporalItems.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/TemporalItems.java
@@ -4,6 +4,7 @@ import com.faridfaharaj.profitable.Configuration;
 import com.faridfaharaj.profitable.Profitable;
 import com.faridfaharaj.profitable.data.tables.Assets;
 import com.faridfaharaj.profitable.data.holderClasses.Asset;
+import com.faridfaharaj.profitable.util.ItemMetaCompat;
 import com.faridfaharaj.profitable.util.MessagingUtil;
 
 import org.bukkit.Material;
@@ -115,7 +116,7 @@ public class TemporalItems {
 
         if (meta != null) {
             meta.setDisplayName(displayName);
-            meta.setEnchantmentGlintOverride(true);
+            ItemMetaCompat.setEnchantmentGlintOverride(meta, true);
             item.setItemMeta(meta);
         }
 

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/elements/specific/AssetButton.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/elements/specific/AssetButton.java
@@ -7,6 +7,7 @@ import com.faridfaharaj.profitable.tasks.gui.ChestGUI;
 import com.faridfaharaj.profitable.tasks.gui.elements.GuiElement;
 import com.faridfaharaj.profitable.tasks.gui.guis.GraphsMenu;
 import com.faridfaharaj.profitable.tasks.gui.guis.orderBuilding.BuySellGui;
+import com.faridfaharaj.profitable.util.ItemMetaCompat;
 import com.faridfaharaj.profitable.util.MessagingUtil;
 import com.faridfaharaj.profitable.util.NamingUtil;
 import net.kyori.adventure.text.Component;
@@ -43,7 +44,7 @@ public final class AssetButton extends GuiElement {
         }if(assetData.getAsset().getAssetType() == 1) {
             this.display = new ItemStack(Material.EMERALD);
             ItemMeta meta = this.display.getItemMeta();
-            meta.setEnchantmentGlintOverride(true);
+            ItemMetaCompat.setEnchantmentGlintOverride(meta, true);
             this.display.setItemMeta(meta);
         }
 

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/elements/specific/AssetHolderButton.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/elements/specific/AssetHolderButton.java
@@ -7,6 +7,7 @@ import com.faridfaharaj.profitable.data.holderClasses.Candle;
 import com.faridfaharaj.profitable.tasks.gui.ChestGUI;
 import com.faridfaharaj.profitable.tasks.gui.elements.GuiElement;
 import com.faridfaharaj.profitable.tasks.gui.guis.DepositWithdrawalGui;
+import com.faridfaharaj.profitable.util.ItemMetaCompat;
 import com.faridfaharaj.profitable.util.MessagingUtil;
 import com.faridfaharaj.profitable.util.NamingUtil;
 import net.kyori.adventure.text.Component;
@@ -41,7 +42,7 @@ public final class AssetHolderButton extends GuiElement {
             }if(asset.getAssetType() == 1) {
                 this.display = new ItemStack(Material.EMERALD);
                 ItemMeta meta = this.display.getItemMeta();
-                meta.setEnchantmentGlintOverride(true);
+                ItemMetaCompat.setEnchantmentGlintOverride(meta, true);
                 this.display.setItemMeta(meta);
             }
 

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/AssetExplorer.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/AssetExplorer.java
@@ -183,7 +183,7 @@ public final class AssetExplorer extends ChestGUI {
                 }if(click.isRightClick()){
                     page-=1;
                 }
-                page = Math.clamp(page, 0, pages);
+                page = Math.max(0, Math.min(page, pages));
                 updatePage();
                 pageButton.setDisplayName(Profitable.getLang().get("gui.generic.buttons.page-selector.name",
                         Map.entry("%page%",String.valueOf(page)),

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/HoldingsMenu.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/HoldingsMenu.java
@@ -100,7 +100,7 @@ public final class HoldingsMenu extends ChestGUI {
                 }if(click.isRightClick()){
                     page-=1;
                 }
-                page = Math.clamp(page, 0, pages);
+                page = Math.max(0, Math.min(page, pages));
                 updatePage();
                 pageButton.setDisplayName(Profitable.getLang().get("gui.generic.buttons.page-selector.name",
                         Map.entry("%page%",String.valueOf(page)),

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/UserOrdersGui.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/UserOrdersGui.java
@@ -109,7 +109,7 @@ public final class UserOrdersGui extends ChestGUI {
                 }if(click.isRightClick()){
                     page-=1;
                 }
-                page = Math.clamp(page, 0, pages);
+                page = Math.max(0, Math.min(page, pages));
                 updatePage();
                 pageButton.setDisplayName(Profitable.getLang().get("gui.generic.buttons.page-selector.name",
                         Map.entry("%page%",String.valueOf(page)),

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/orderBuilding/BuySellGui.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/orderBuilding/BuySellGui.java
@@ -63,7 +63,7 @@ public final class BuySellGui extends ChestGUI {
 
             sellLore = Profitable.getLang().langToLore("gui.order-building.buy-sell.buttons.sell.lore",
                     Map.entry("%asset%", this.assetData.getAsset().getCode()),
-                    Map.entry("%ask_asset_amount%", MessagingUtil.assetAmmount(Configuration.MAINCURRENCYASSET, askOrders.getFirst().getPrice())),
+                    Map.entry("%ask_asset_amount%", MessagingUtil.assetAmmount(Configuration.MAINCURRENCYASSET, askOrders.get(0).getPrice())),
                     Map.entry("%price_list%", prices.toString())
             );
         }else {
@@ -91,7 +91,7 @@ public final class BuySellGui extends ChestGUI {
 
             buyLore = Profitable.getLang().langToLore("gui.order-building.buy-sell.buttons.buy.lore",
                     Map.entry("%asset%", this.assetData.getAsset().getCode()),
-                    Map.entry("%bid_asset_amount%", MessagingUtil.assetAmmount(Configuration.MAINCURRENCYASSET, bidOrders.getFirst().getPrice())),
+                    Map.entry("%bid_asset_amount%", MessagingUtil.assetAmmount(Configuration.MAINCURRENCYASSET, bidOrders.get(0).getPrice())),
                     Map.entry("%price_list%", prices.toString())
             );
         }else {

--- a/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/orderBuilding/PriceSelect.java
+++ b/src/main/java/com/faridfaharaj/profitable/tasks/gui/guis/orderBuilding/PriceSelect.java
@@ -29,7 +29,7 @@ public final class PriceSelect  extends QuantitySelectGui {
     AssetCache assetData;
     public PriceSelect(AssetCache[][] assetCache, AssetCache assetData, Order order, List<Order> bidOrders, List<Order> askOrders) {
         super(Profitable.getLang().get("gui.order-building.price-select.title"), true, false,
-                Math.max(order.isSideBuy()? (bidOrders.isEmpty()? assetData.getlastCandle().getClose() : bidOrders.getFirst().getPrice()) :(askOrders.isEmpty()? assetData.getlastCandle().getClose() : askOrders.getFirst().getPrice()), 0.001)
+                Math.max(order.isSideBuy()? (bidOrders.isEmpty()? assetData.getlastCandle().getClose() : bidOrders.get(0).getPrice()) :(askOrders.isEmpty()? assetData.getlastCandle().getClose() : askOrders.get(0).getPrice()), 0.001)
         );
         this.assetCache = assetCache;
         this.assetData = assetData;

--- a/src/main/java/com/faridfaharaj/profitable/util/ItemMetaCompat.java
+++ b/src/main/java/com/faridfaharaj/profitable/util/ItemMetaCompat.java
@@ -1,0 +1,33 @@
+package com.faridfaharaj.profitable.util;
+
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.lang.reflect.Method;
+
+public final class ItemMetaCompat {
+
+    private static final Method SET_ENCHANTMENT_GLINT_OVERRIDE = findSetEnchantmentGlintOverride();
+
+    private ItemMetaCompat() {
+    }
+
+    public static void setEnchantmentGlintOverride(ItemMeta meta, boolean enabled) {
+        if (meta == null || SET_ENCHANTMENT_GLINT_OVERRIDE == null) {
+            return;
+        }
+
+        try {
+            SET_ENCHANTMENT_GLINT_OVERRIDE.invoke(meta, enabled);
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            // Older server APIs do not support forced glint; the item remains usable without it.
+        }
+    }
+
+    private static Method findSetEnchantmentGlintOverride() {
+        try {
+            return ItemMeta.class.getMethod("setEnchantmentGlintOverride", Boolean.class);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/faridfaharaj/profitable/util/MessagingUtil.java
+++ b/src/main/java/com/faridfaharaj/profitable/util/MessagingUtil.java
@@ -44,7 +44,7 @@ public class MessagingUtil {
         if(!asset.getStringData().isEmpty()){
             component = component.appendNewline();
 
-            String[] words = asset.getStringData().getFirst().split(" ");
+            String[] words = asset.getStringData().get(0).split(" ");
             int linelen = 0;
             for (String word : words) {
                 linelen += word.length();

--- a/src/main/java/com/faridfaharaj/profitable/util/ParticleCompat.java
+++ b/src/main/java/com/faridfaharaj/profitable/util/ParticleCompat.java
@@ -1,0 +1,28 @@
+package com.faridfaharaj.profitable.util;
+
+import org.bukkit.Particle;
+
+public final class ParticleCompat {
+
+    private static final Particle FIREWORK = resolve("FIREWORK", Particle.FIREWORKS_SPARK);
+    private static final Particle HAPPY_VILLAGER = resolve("HAPPY_VILLAGER", Particle.VILLAGER_HAPPY);
+
+    private ParticleCompat() {
+    }
+
+    public static Particle firework() {
+        return FIREWORK;
+    }
+
+    public static Particle happyVillager() {
+        return HAPPY_VILLAGER;
+    }
+
+    private static Particle resolve(String name, Particle fallback) {
+        try {
+            return Particle.valueOf(name);
+        } catch (IllegalArgumentException ignored) {
+            return fallback;
+        }
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 main: com.faridfaharaj.profitable.Profitable
 author: faridfaharaj
 prefix: "Profitable"
-api-version: '1.21'
+api-version: '1.20'
 description: "Real supply and demand in minecraft!"
 website: "https://github.com/faridfaharaj/Profitable"
 softdepend:


### PR DESCRIPTION
## Summary
- build against Paper 1.20.4 and Java 17 with plugin api-version 1.20
- replace Java 21-only collection helpers and Math.clamp calls with Java 17-compatible code
- add compatibility helpers for the newer item glint API and renamed particle constants
- update FoliaLib to its published com.tcoded coordinate so Maven can resolve it

Closes #41.

## Validation
- mvn -q -DskipTests package using Java 17
- git diff --check
- verified the built jar is Java 17 bytecode and contains api-version: '1.20'